### PR TITLE
Ensure date and pax label have full size, the rest for remarks

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -98,10 +98,12 @@ public class PersonCard extends UiPart<Region> {
 
                 Label dateTimeLabel = new Label(formatDateTime(booking.getBookingDateTime()));
                 dateTimeLabel.getStyleClass().add("yellow-tag");
+                dateTimeLabel.setMinWidth(Region.USE_PREF_SIZE);
                 bookingDetails.getChildren().add(dateTimeLabel);
 
                 Label paxLabel = new Label(booking.getPax() + " pax");
                 paxLabel.getStyleClass().add("purple-tag");
+                paxLabel.setMinWidth(Region.USE_PREF_SIZE);
                 bookingDetails.getChildren().add(paxLabel);
 
                 if (!booking.getRemarks().isEmpty()) {


### PR DESCRIPTION
Partial contribution to #207
This is not a full solution, but rather I add this because I had a PR on Person Cards' layout.
The booking card adjustments will still be by isa.